### PR TITLE
Removed random

### DIFF
--- a/utils/iterators.py
+++ b/utils/iterators.py
@@ -1,6 +1,3 @@
-import random
-
-
 class RandomKeyIterator:
 
     def __init__(self, keys: list):
@@ -18,7 +15,11 @@ class RandomKeyIterator:
         if not self.keys:
             self._reset()
 
-        key = random.choice(self.keys)
-        self.keys.pop(self.keys.index(key))
+        key = self.keys.pop(-1)
         self.visited.append(key)
         return key
+
+if __name__ == "__main__":
+        keys = RandomKeyIterator([1, 2, 3, 4, 5])
+        for i in keys:
+            print(i)

--- a/utils/iterators.py
+++ b/utils/iterators.py
@@ -18,8 +18,3 @@ class RandomKeyIterator:
         key = self.keys.pop(-1)
         self.visited.append(key)
         return key
-
-if __name__ == "__main__":
-        keys = RandomKeyIterator([1, 2, 3, 4, 5])
-        for i in keys:
-            print(i)


### PR DESCRIPTION
Having a `pop()` call and not using its return value is only getting around half the efficiency of the function itself. 
Instead of using `random` to determine the key we want, we remove the necessity of having random in this script entirely by using `pop()` for this instead.

I would also like to note that in this way, the keys returned generate a "wave" pattern.
`5, 4, 3, 2, 1, 1, 2, 3, 4, 5, 5, 4, 3, 2, 1, 1, 2, 3, 4, 5`

If the use of "random" in this script was for "humanization", then using this method might make it more detectable. 
However, the actual order the keys are pressed shouldn't actually matter too much. 
Humanization comes more into effect around _when_ the keys are actually pressed. 
For example, if there is a small bit of delay around each keypress, offsetting the actuation of each key.
It's more likely someone will press the keys in the exact same order and pattern, but with different timing. 
So in a sense, this could actually also help with "Huminizing" this script.